### PR TITLE
Add further deadpan lines to the Director of Happiness listing

### DIFF
--- a/careers/index.html
+++ b/careers/index.html
@@ -405,6 +405,8 @@
         <dl>
           <dt>Location</dt>
           <dd>Hybrid (Berlin, with occasional travel)</dd>
+          <dt>Travel</dt>
+          <dd>Occasional overnight</dd>
           <dt>Employment Type</dt>
           <dd>Permanent, Flexible</dd>
           <dt>Department</dt>
@@ -446,9 +448,12 @@
         <ul>
           <li>Demonstrated emotional intelligence.</li>
           <li>Strong communication skills.</li>
+          <li>Good listening skills, including sensitivity to non-verbal cues.</li>
           <li>Comfortable setting boundaries.</li>
           <li>Able to distinguish facts from stories the CEO occasionally invents in his own head.</li>
+          <li>Hands-on mentality.</li>
           <li>Appreciation for curiosity, music and good food.</li>
+          <li>Resilience and stamina under sustained load.</li>
           <li>Independent life outside of work.</li>
           <li>Comfortable with moderate levels of nerdiness.</li>
         </ul>
@@ -459,6 +464,7 @@
         <ul>
           <li>Festival experience.</li>
           <li>Ability to appreciate both quiet evenings and slightly chaotic weekends.</li>
+          <li>Prior experience in a fast-paced, high-touch environment.</li>
           <li>Doesn't mind appearing in photos from time to time.</li>
           <li>Enjoys discovering caf&eacute;s, restaurants or places without requiring a detailed spreadsheet first.</li>
           <li>Basic cat fluency ("mauu") is considered an advantage.</li>
@@ -471,6 +477,7 @@
           <li>High degree of autonomy.</li>
           <li>Flexible working model with no mandatory office days.</li>
           <li>Freedom to pursue personal projects and interests.</li>
+          <li>Regular one-on-ones.</li>
           <li>Competitive snack budget.</li>
           <li>Access to experimental dinners before they become edible.</li>
           <li>Occasional airport pickup.</li>
@@ -485,6 +492,7 @@
         <h2>Our Culture</h2>
         <p>We believe the best partnerships are built on trust, independence and mutual curiosity.</p>
         <p>We value honesty over perfection, communication over assumptions, and making memories over optimizing them.</p>
+        <p>We work in short, intense sprints followed by proper recovery.</p>
         <p>You won't be expected to complete the CEO&mdash;you'll simply make an already good life even more enjoyable.</p>
       </section>
 
@@ -525,6 +533,9 @@
 
         <h3>Is prior experience mandatory?</h3>
         <p>Not necessarily. Genuine enthusiasm tends to outperform r&eacute;sum&eacute;s.</p>
+
+        <h3>Is there a dress code?</h3>
+        <p>Not strictly enforced.</p>
 
         <h3>Is there a probation period?</h3>
         <p>No. We generally prefer discovering whether we enjoy working together naturally.</p>


### PR DESCRIPTION
Follow-up to #28. Adds eight lines to `careers/index.html`, each phrased as standard job-ad boilerplate so it reads flat against the surrounding copy.

| Section | Line |
|---|---|
| Meta block | `Travel: Occasional overnight` |
| Required qualifications | Good listening skills, including sensitivity to non-verbal cues. |
| Required qualifications | Hands-on mentality. |
| Required qualifications | Resilience and stamina under sustained load. |
| Nice to have | Prior experience in a fast-paced, high-touch environment. |
| Benefits | Regular one-on-ones. |
| Our Culture | We work in short, intense sprints followed by proper recovery. |
| FAQ | *Is there a dress code?* → Not strictly enforced. |

Placement notes:

- The three in **Required qualifications** are separated by existing bullets so they don't read as a run.
- **Benefits** takes its line at position four, clear of "performance reviews are generally conducted face-to-face" and "regular off-sites".
- The **dress code** FAQ sits second-to-last, leaving "probation period" as the closer.
- **Travel** sits under Location, reading as an elaboration of "with occasional travel".

No existing copy was modified — every change is a new line. Rendering verified at 1280px and 390px; the meta table still collapses to stacked label/value on mobile with the added row.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGpd3d7PsZrEkimMQrHK3n)_